### PR TITLE
File import fix for Ember 3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,36 +1,17 @@
 /* eslint-env node */
 'use strict';
 
-const path = require('path');
-const Funnel = require('broccoli-funnel');
-const mergeTrees = require('broccoli-merge-trees');
-
 module.exports = {
   name: 'ember-jwt-decode',
 
   included(app) {
     this._super.included(app);
 
-    app.import('vendor/ember-jwt-decode/jwt-decode.js', {
+    app.import('node_modules/jwt-decode/build/jwt-decode.min.js', {
       using: [
         { transformation: 'amd', as: 'jwt-decode' }
       ]
     });
     app.import('vendor/ember-jwt-decode/shims/jwt-decode.js');
-  },
-
-  jwtDecodePath() {
-    return path.join(this.app.project.nodeModulesPath, 'jwt-decode', 'build');
-  },
-
-  treeForVendor(tree) {
-    let trees = [tree];
-
-    trees.push(new Funnel(this.jwtDecodePath(), {
-      destDir: 'ember-jwt-decode',
-      files: ['jwt-decode.js']
-    }));
-
-    return mergeTrees(trees);
-  },
+  }
 };

--- a/package.json
+++ b/package.json
@@ -20,15 +20,14 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "broccoli-funnel": "^1.2.0",
-    "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.3.0",
-    "jwt-decode": "^2.2.0"
+    "jwt-decode": "^2.2.0",
+    "resolve": "^1.5.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
-    "ember-cli": "~2.14.1",
+    "ember-cli": "~3.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-fastboot": "^1.0.5",
@@ -44,7 +43,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.14.1",
+    "ember-source": "~3.0.0",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
-    "ember-cli": "~3.0.0",
+    "ember-cli": "~2.15.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-fastboot": "^1.0.5",
@@ -42,7 +42,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~3.0.0",
+    "ember-source": "~2.15.0",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.3.0",
-    "jwt-decode": "^2.2.0",
-    "resolve": "^1.5.0"
+    "jwt-decode": "^2.2.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
Fixes issue https://github.com/Exelord/ember-jwt-decode/issues/1

In Ember 2.18, the usage of `this.app.project.nodeModulesPath` results in this warning:

`DEPRECATION: An addon is trying to access project.nodeModulesPath. This is not a reliable way to discover npm modules. Instead, consider doing: require("resolve").sync(something, { basedir: project.root }).`


In Ember 3.0, the usage of `this.app.project.nodeModuelsPath` is no longer allowed, as the above GitHub issue states.

Beginning in Ember CLI 2.15, you can now import files directly from the `node_modules` directory. I fixed this issue by simply importing `jwt-decode` directly from node_modules, instead of copying it to vendor and then importing it from vendor.